### PR TITLE
Fix/allow only market selectable dates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,12 +51,27 @@ export default {
         symbol: symbol,
         isLoading: true
       });
+      const today = new Date();
+      const threeMonthsAgo = new Date(
+        today.getFullYear(),
+        today.getMonth() - 3,
+        today.getDate()
+      );
+      const initialDate = new Date(
+        this.dates.initial.slice(0, 4),
+        this.dates.initial.slice(5, 7),
+        this.dates.initial.slice(8, 10)
+      );
+
+      const outputsize = initialDate > threeMonthsAgo ? "compact" : "full";
+
       axios
         .get("https://www.alphavantage.co/query", {
           params: {
             function: "TIME_SERIES_DAILY",
             symbol: symbol,
-            apikey: apikey
+            apikey: apikey,
+            outputsize: outputsize
           }
         })
         .then(response => {

--- a/src/components/control-panel/date-range-selector/DateRangeSelector.vue
+++ b/src/components/control-panel/date-range-selector/DateRangeSelector.vue
@@ -6,6 +6,8 @@
         placeholder="Click to select..."
         v-model="dates"
         :style="datePickerStyle"
+        :min-date="minDate"
+        :max-date="maxDate"
         @input="updateDates"
         range
       ></b-datepicker>
@@ -21,6 +23,8 @@ export default {
     finalDateUpdater: Function
   },
   data() {
+    const today = new Date();
+
     return {
       datePickerStyle: {
         marginTop: "0em"
@@ -32,8 +36,13 @@ export default {
         padding: "0.4rem 0rem",
         width: "100%"
       },
-      dates: []
-      // [startDate, endDate]
+      dates: [],
+      minDate: new Date(
+        today.getFullYear() - 19,
+        today.getMonth(),
+        today.getDate()
+      ),
+      maxDate: new Date()
     };
   },
   methods: {

--- a/src/components/control-panel/date-range-selector/DateRangeSelector.vue
+++ b/src/components/control-panel/date-range-selector/DateRangeSelector.vue
@@ -8,6 +8,8 @@
         :style="datePickerStyle"
         :min-date="minDate"
         :max-date="maxDate"
+        :unselectable-days-of-week="unselectableDaysOfWeek"
+        :unselectable-dates="unselectableDates"
         @input="updateDates"
         range
       ></b-datepicker>
@@ -42,7 +44,10 @@ export default {
         today.getMonth(),
         today.getDate()
       ),
-      maxDate: new Date()
+      maxDate: new Date(),
+      unselectableDaysOfWeek: [0, 6],
+      // ToDO: Need to block out dates the market has been closed that _aren't_ weekends.
+      unselectableDates: []
     };
   },
   methods: {


### PR DESCRIPTION
Fix #17 #12 

Switch to fetching the full price list when the initial date is sufficiently old.